### PR TITLE
README: document how to run plugin locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,27 @@ or manually using this URL:
 ## Configuration
 
 Follow [Obico Setup Guide](https://www.obico.io/docs/user-guides/octoprint-plugin-setup/) to set up this plugin.
+
+
+# Plugin Development
+
+## Running the plugin locally
+
+```bash
+docker compose up -d
+```
+
+Will start a series of containers that support the plugin (eg mock video streaming) as well as an octoprint container for python2 and python3. However, to enable interactive debugging the plugin containers are not running the plugins yet. 
+
+In another terminal:
+
+To install the plugin in the container run:
+```bash
+docker compose exec {op/op_python_2} octoprint dev plugin:install
+```
+
+Then to start octoprint (and by extension the plugin) run:
+
+```bash
+docker compose exec {op/op_python2} ./start.sh
+```


### PR DESCRIPTION
The current README is sparse on how to get started with developing it. 

This PR adds a new section with local development instructions. 

From reviewers: 
* Are there better ways to install and run the plugin than what I have here?
* Should the plugin install be done as part of the octoprint container startup automatically?