### PR TITLE
Disabled TorandoIntegration of sentry sdk

### DIFF
--- a/octoprint_obico/utils.py
+++ b/octoprint_obico/utils.py
@@ -5,6 +5,7 @@ import logging
 import sentry_sdk
 from sentry_sdk.integrations.threading import ThreadingIntegration
 from sentry_sdk.integrations.logging import LoggingIntegration
+from sentry_sdk.integrations.flask import FlaskIntegration
 import re
 import os
 import platform
@@ -104,12 +105,14 @@ class SentryWrapper:
         self.plugin = plugin
         sentry_sdk.init(
             dsn='https://f0356e1461124e69909600a64c361b71@sentry.obico.io/4',
+            default_integrations=False,
             integrations=[
                 ThreadingIntegration(propagate_hub=True), # Make sure context are propagated to sub-threads.
                 LoggingIntegration(
                     level=logging.INFO, # Capture info and above as breadcrumbs
                     event_level=None  # Send logs as events above a logging level, disabled it
                 ),
+                FlaskIntegration(),
             ],
             before_send=before_send,
 


### PR DESCRIPTION
When using octoprint==1.7.0+ and octoprint_obico==2.1.0+ togehter, then
on can see these errors in the log when visiting octoprint web app:

```
2022-07-18 14:24:15,627 - asyncio - ERROR - Exception in callback _HandlerDelegate.execute.<locals>.<lambda>(<Task finishe...didn't stop")>) at /Users/gmo/w/tsd/OctoPrint-Obico/.v/lib/python3.9/site-packages/tornado/web.py:2361
handle: <Handle _HandlerDelegate.execute.<locals>.<lambda>(<Task finishe...didn't stop")>) at /Users/gmo/w/tsd/OctoPrint-Obico/.v/lib/python3.9/site-packages/tornado/web.py:2361>
Traceback (most recent call last):
  File ".../env/versions/3.9.5/lib/python3.9/asyncio/events.py", line 80, in _run
    self._context.run(self._callback, *self._args)
  File ".../env/lib/python3.9/site-packages/tornado/web.py", line 2361, in <lambda>
    fut.add_done_callback(lambda f: f.result())
  File ".../env/lib/python3.9/site-packages/sentry_sdk/integrations/tornado.py", line 71, in sentry_execute_request_handler
    return await old_execute(self, *args, **kwargs)
  File ".../env/versions/3.9.5/lib/python3.9/contextlib.py", line 128, in __exit__
    raise RuntimeError("generator didn't stop")
RuntimeError: generator didn't stop
```

The exact problem is not yet understood, but it's safe to ignore
tornado related errors as it's not a direct dependency of the obico plugin.

Disabled default setntry integrations (it's all or nothing), what contains TornadoIntegration.
Added back FlaskIntegration to cover those endpoints provided by obico
plugin.