### PR TITLE
Allow non-TLD URLs in Obico wizard

### DIFF
--- a/octoprint_obico/static/js/ObicoWizard.js
+++ b/octoprint_obico/static/js/ObicoWizard.js
@@ -44,7 +44,7 @@ $(function () {
         self.isServerInvalid = ko.observable(false);
 
         self.checkSeverValidity = (url) => {
-            return /^https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)$/.test(url);
+            return /^https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)$/.test(url);
         }
 
         // Handle verification code typing:


### PR DESCRIPTION
#170 

Verified using https://regex101.com/   (ECMAScript/Javascript flavor) with the following test inputs:

**Valid**

* http://asdf.test:4949
* http://hostname:4949
* http://a.b.c:4949/def
* http://abc/def
* http://abc
* https://abc:4949

**Invalid**

* abc
* abc:4949

