### PR TITLE
Fix for filament change duplicate Obico emails

### DIFF
--- a/octoprint_obico/gcode_hooks.py
+++ b/octoprint_obico/gcode_hooks.py
@@ -21,7 +21,8 @@ class GCodeHooks:
         return line
 
     def check_for_filament_change(self, gcode=None, line=None):
-        self.num_gcode_until_next_filament_change -= 1
+        if gcode:
+            self.num_gcode_until_next_filament_change -= 1
         if self.num_gcode_until_next_filament_change > 0:
             return
 


### PR DESCRIPTION
Very simple fix - problem was that each new terminal line was decrementing the gcode counter which quickly decremented down to zero since temperature status messages are sent continually.