### PR TITLE
Feat: Add rate limit to sentry event

### DIFF
--- a/octoprint_obico/__init__.py
+++ b/octoprint_obico/__init__.py
@@ -188,7 +188,8 @@ class ObicoPlugin(
             elif event == 'FilamentChange':
                 run_in_thread(self.post_filament_change_event)
         except Exception as e:
-            self.sentry.captureException()
+            _logger.error(e)
+            # self.sentry.captureException()
     # ~~Shutdown Plugin
 
     def on_shutdown(self):
@@ -288,7 +289,8 @@ class ObicoPlugin(
                     self.post_update_to_server()
 
             except Exception as e:
-                self.sentry.captureException()
+                _logger.error(e)
+                # self.sentry.captureException()
 
             time.sleep(1)
 
@@ -352,7 +354,8 @@ class ObicoPlugin(
                     self.ss.close()
                 server_ws_backoff.more(e)
             except Exception as e:
-                self.sentry.captureException()
+                # self.sentry.captureException()
+                _logger.error(e)
                 error_stats.add_connection_error('server', self)
                 if self.ss:
                     self.ss.close()
@@ -440,8 +443,9 @@ class ObicoPlugin(
 
             if need_status_boost:
                 self.boost_status_update()
-        except:
-            self.sentry.captureException()
+        except BaseException as e:
+            _logger.error(e)
+            # self.sentry.captureException()
 
     def status_update_to_client_loop(self):
         while self.shutting_down is False:

--- a/octoprint_obico/tunnel.py
+++ b/octoprint_obico/tunnel.py
@@ -111,8 +111,9 @@ class LocalTunnel(object):
                 self.on_ws_message(
                     {'ws.tunnel': {'ref': ref, 'data': data, 'type': 'octoprint_message'}},
                     as_binary=True)
-            except:
-                self.sentry.captureException()
+            except BaseException as e:
+                _logger.error(e)
+                # self.sentry.captureException()
                 ws.close()
 
         url = urljoin(self.base_url, path)

--- a/octoprint_obico/utils.py
+++ b/octoprint_obico/utils.py
@@ -3,6 +3,7 @@ import time
 import random
 import logging
 import sentry_sdk
+from ratelimitingfilter import RateLimitingFilter
 from sentry_sdk.integrations.threading import ThreadingIntegration
 from sentry_sdk.integrations.logging import LoggingIntegration
 from sentry_sdk.integrations.flask import FlaskIntegration
@@ -124,16 +125,24 @@ class SentryWrapper:
                     return None
             return event
 
+        sentry_logging = LoggingIntegration(
+            level=logging.INFO,  # Capture info and above as breadcrumbs
+            event_level=logging.ERROR  # Send errors as events
+        )
+
+        rate_limit = RateLimitingFilter(rate=1, per=600, burst=10)
+        sentry_logging._handler.addFilter(rate_limit)
 
         sentry_sdk.init(
             dsn='https://f0356e1461124e69909600a64c361b71@sentry.obico.io/4',
             default_integrations=False,
             integrations=[
                 ThreadingIntegration(propagate_hub=True), # Make sure context are propagated to sub-threads.
-                LoggingIntegration(
-                    level=logging.INFO, # Capture info and above as breadcrumbs
-                    event_level=None  # Send logs as events above a logging level, disabled it
-                ),
+                sentry_logging,
+                # LoggingIntegration(
+                #     level=logging.INFO, # Capture info and above as breadcrumbs
+                #     event_level=None  # Send logs as events above a logging level, disabled it
+                # ),
                 FlaskIntegration(),
             ],
             before_send=before_send,

--- a/octoprint_obico/webcam_stream.py
+++ b/octoprint_obico/webcam_stream.py
@@ -203,8 +203,9 @@ class WebcamStreamer:
                             'text': 'Octolapse plugin detected! Obico has switched to "Premium (compatibility)" streaming mode.',
                             'buttons': ['never', 'ok']
                         }, self.plugin)
-                except Exception:
-                    self.sentry.captureException()
+                except Exception as e:
+                    _logger.error(e)
+                    # self.sentry.captureException()
 
             if compatible_mode == 'always':
                 self.ffmpeg_from_mjpeg()
@@ -244,7 +245,7 @@ class WebcamStreamer:
                 self.webcam_server.start()
                 self.pi_camera.start_recording(self.ffmpeg_proc.stdin, format='h264', quality=23, intra_period=25, profile='baseline')
                 self.pi_camera.wait_recording(0)
-        except Exception:
+        except Exception as e:
             alert_queue.add_alert({
                 'level': 'warning',
                 'cause': 'streaming',
@@ -255,7 +256,8 @@ class WebcamStreamer:
             }, self.plugin, post_to_server=True)
 
             self.restore()
-            self.sentry.captureException()
+            _logger.error(e)
+            # self.sentry.captureException()
 
     @backoff.on_exception(backoff.expo, Exception, max_tries=3)
     def ffmpeg_from_mjpeg(self):
@@ -294,8 +296,9 @@ class WebcamStreamer:
             _logger.debug(f'Detected webcam resolution - w:{img_w} / h:{img_h}')
         except (URLError, HTTPError, requests.exceptions.RequestException):
             _logger.warn('Failed to connect to webcam to retrieve resolution. Using default.')
-        except Exception:
-            self.sentry.captureException()
+        except Exception as e:
+            _logger.error(e)
+            # self.sentry.captureException()
             _logger.warn('Failed to detect webcam resolution due to unexpected error. Using default.')
 
         bitrate = bitrate_for_dim(img_w, img_h)
@@ -463,10 +466,12 @@ class UsbCamWebServer:
             pass
         except socket.error as err:
             if err.errno not in [errno.ECONNREFUSED, ]:
-                self.sentry.captureException()
+                _logger.error(err)
+                # self.sentry.captureException()
             raise
-        except Exception:
-            self.sentry.captureException()
+        except Exception as e:
+            _logger.error(e)
+            # self.sentry.captureException()
             raise
         finally:
             s.close()
@@ -499,8 +504,9 @@ class UsbCamWebServer:
             exc_type, exc_obj, exc_tb = sys.exc_info()
             _logger.error(exc_obj)
             raise
-        except Exception:
-            self.sentry.captureException()
+        except Exception as e:
+            _logger.error(e)
+            # self.sentry.captureException()
             raise
         finally:
             s.close()
@@ -580,8 +586,9 @@ class PiCamWebServer:
                     self.last_capture = time.time()
 
                 self.img_q.put(chunk)
-        except Exception:
-            self.sentry.captureException()
+        except Exception as e:
+            _logger.error(e)
+            # self.sentry.captureException()
             raise
 
     def mjpeg_generator(self, boundary):
@@ -597,8 +604,9 @@ class PiCamWebServer:
                 time.sleep(0.15)  # slow down mjpeg streaming so that it won't use too much cpu or bandwidth
         except GeneratorExit:
             pass
-        except Exception:
-            self.sentry.captureException()
+        except Exception as e:
+            _logger.error(e)
+            # self.sentry.captureException()
             raise
 
     def get_snapshot(self):

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ plugin_url = "https://www.obico.io/"
 plugin_license = "AGPLv3"
 
 # Any additional requirements besides OctoPrint should be listed here
-plugin_requires = ["OctoPrint>=1.5.0", "backoff>=1.4.3", "sentry-sdk>=1.5.12", "bson>=0.5.10"]
+plugin_requires = ["OctoPrint>=1.5.0", "backoff>=1.4.3", "ratelimitingfilter>=1.5", "sentry-sdk>=1.5.12", "bson>=0.5.10"]
 
 ### --------------------------------------------------------------------------------------------------------------------
 ### More advanced options that you usually shouldn't have to touch follow after this point


### PR DESCRIPTION
This PR covers:

Changes:
1. Change `self.sentry.captureException()` to `_logger.error(e)` since the former does not rely on std logging. so it does not work with rate limit
2. Set a rate limit for a burst of 10, then 1 per 10 minutes.

New:
1. Add new dependency: `ratelimitingfilter `. run `pip3 install -e .` to install first.