### PR TITLE
Update webcam_stream.py if not running webcamd or no sudo

### DIFF
--- a/octoprint_obico/webcam_stream.py
+++ b/octoprint_obico/webcam_stream.py
@@ -210,7 +210,7 @@ class WebcamStreamer:
                 self.ffmpeg_from_mjpeg()
                 return
 
-            if sarge.run('sudo service webcamd stop').returncodes[0] != 0:
+            if sarge.run('systemctl is-active webcamd').returncodes[0] == 0 and sarge.run('sudo service webcamd stop').returncodes[0] != 0:
                 self.ffmpeg_from_mjpeg()
                 return
 


### PR DESCRIPTION
Currently, if you don't have 'webcamd' installed as a service or if you don't have 'sudo' access, the line `sudo service webcamd stop` will fail causing the streaming to revert to `ffmpeg_from_mjpeg` even if your current stream is perfectly fine...

Added a test whether `webcamd` is even active before trying to shut it down

See https://github.com/TheSpaghettiDetective/OctoPrint-Obico/issues/225 for more details