### PR TITLE
Use which instead of dpkg for Fedora support

### DIFF
--- a/octoprint_obico/janus_config_builder.py
+++ b/octoprint_obico/janus_config_builder.py
@@ -33,7 +33,7 @@ def find_system_janus_paths():
     janus_lib_path = None
 
     try:
-        output = subprocess.check_output(['dpkg', '-L', 'janus'], universal_newlines=True)
+        output = subprocess.check_output(['which', 'janus'], universal_newlines=True)
         paths = output.split('\n')
 
         # janus binary path if only 1 line ends with /bin/janus


### PR DESCRIPTION
My system is on Fedora, and after getting Janus installed manually, the plugin still can't find it due to the use of dpkg here.

The documentation here mentions Fedora, and also needs to be updated as it doesn't exist in the Fedora repos, I had to install it manually.
https://www.obico.io/docs/user-guides/webcam-install-janus/